### PR TITLE
fixed simple-validator for non primitive types

### DIFF
--- a/simple-validator/src/validator.ts
+++ b/simple-validator/src/validator.ts
@@ -10,7 +10,9 @@ export function isValid(object: any, interfaceObj: Interface): boolean {
                 return false;
             } else if (member.type.kind === 'interface' && object[member.name] != null) {
                 // recursively check field type against the corresponding interface
-                return isValid(object[member.name], <Interface>member.type);
+                if(!isValid(object[member.name], <Interface>member.type)) {
+                    return false;
+                }
             }
             // TODO: check class types...
         }


### PR DESCRIPTION
If a nested non primitive member is valid, validation terminates prematurely. This code change ensures all members are properly validated when non primitive members are declared into the interface.
